### PR TITLE
Adding support for JPEG/WASM assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset_util"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.21.7",
  "candid",

--- a/src/asset_util/Cargo.toml
+++ b/src/asset_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset_util"
 description = "Asset certification utility library for asset serving canisters"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -359,6 +359,8 @@ pub enum ContentType {
     PNG,
     SVG,
     WOFF2,
+    WASM,
+    JPG,
 }
 
 impl ContentType {
@@ -374,6 +376,8 @@ impl ContentType {
             ContentType::PNG => "image/png".to_string(),
             ContentType::SVG => "image/svg+xml".to_string(),
             ContentType::WOFF2 => "application/font-woff2".to_string(),
+            ContentType::WASM => "application/wasm".to_string(),
+            ContentType::JPG => "image/jpeg".to_string(),
         }
     }
 }
@@ -503,6 +507,8 @@ fn content_type_and_encoding(asset_path: &Path) -> (ContentType, ContentEncoding
         "svg" => ContentType::SVG,
         "webp" => ContentType::WEBP,
         "woff2" => ContentType::WOFF2,
+        "wasm" => ContentType::WASM,
+        "jpg" | "jpeg" => ContentType::JPG,
         ext => panic!(
             "Unknown asset type '{}' for asset '{}'",
             ext,
@@ -728,6 +734,21 @@ fn should_return_correct_extension() {
             "path16.dot/gz_json_file.json.gz",
             ContentType::JSON,
             ContentEncoding::GZip,
+        ),
+        (
+            "path17.dot/wasm_file.wasm",
+            ContentType::WASM,
+            ContentEncoding::Identity,
+        ),
+        (
+            "path18.dot/jpg_file.jpg",
+            ContentType::JPG,
+            ContentEncoding::Identity,
+        ),
+        (
+            "path19.dot/jpg_file.jpeg",
+            ContentType::JPG,
+            ContentEncoding::Identity,
         ),
     ];
     for (path, expected_extension, expected_encoding) in path_extension_encoding {


### PR DESCRIPTION
Adding support for JPEG/WASM assets to the asset_util crate.
- JPEG accepts both .jpg and .jpeg files

